### PR TITLE
Update PickUpCardQuest.java

### DIFF
--- a/src/main/java/infinitespire/quests/PickUpCardQuest.java
+++ b/src/main/java/infinitespire/quests/PickUpCardQuest.java
@@ -52,7 +52,7 @@ public class PickUpCardQuest extends Quest {
 		}
 
 		if(c != null) {
-			switch (CardLibrary.getCard(this.cardID).type) {
+			switch (c.type) {
 				case ATTACK:
 					texture = InfiniteSpire.getTexture("img/infinitespire/ui/questLog/questIcons/card-attack.png");
 					break;
@@ -105,8 +105,8 @@ public class PickUpCardQuest extends Quest {
 
 	@Override
 	public String getTitle() {
-
-		return questStrings.TEXT[10] + CardLibrary.cards.get(cardID).name;
+		AbstractCard rCard = CardLibrary.getCard(this.cardID);
+		return questStrings.TEXT[10] + (rCard != null ? rCard.name : "");
 	}
 
 	@Override


### PR DESCRIPTION
getTitle() would crash if no card was found. This would happen if the card no longer exists (i.e. mods were unloaded), but it would also crash for Fabricate cards because it pulls directly from CardLibrary.cards instead of using CardLibrary.getCard like the other methods in this class.

The "c" variable in getTexture() was ignored (which I am assuming was not intentional), which resulted in getCard() getting called twice in that method.